### PR TITLE
FLW-75 , last name is editable when adding spouse

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
@@ -1160,7 +1160,7 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
                 firstName.value = hoFSpouse.genDetails?.spouseName
                 firstName.inputType = TEXT_VIEW
                 lastName.value = hoFSpouse.lastName
-                lastName.inputType = TEXT_VIEW
+                lastName.inputType = EDIT_TEXT
             }
             if (hoFSpouse.gender == FEMALE) {
                 wifeName.value = "${hoFSpouse.firstName} ${hoFSpouse.lastName ?: ""}"


### PR DESCRIPTION
Last name field to be editable when adding the spouse for the Wife(HoF).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `lastName` field in the registration form now allows users to input and modify their last name directly, enhancing user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->