### PR TITLE
FLW-79 , FLW-80  In child infant registration change weight kg to gram and changes in HBYC age group.

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/Dataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/Dataset.kt
@@ -714,6 +714,19 @@ abstract class Dataset(context: Context, currentLanguage: Languages) {
         return -1
     }
 
+    protected fun validateWeightOnEditText(formElement: FormElement): Int {
+
+        formElement.value?.takeIf { it.isNotEmpty() }?.let {
+            if (it.all { it == '0' })
+                formElement.errorText = "Weight Cannot be 0"
+            else if(it.toInt() > 7000)
+                formElement.errorText = "Weight Should not be greater than 7000 gram"
+            else
+                formElement.errorText = null
+        } ?: kotlin.run { formElement.errorText = null }
+        return -1
+    }
+
 
     protected fun validateMcpOnEditText(formElement: FormElement): Int {
         formElement.errorText = formElement.value?.takeIf { it.isNotEmpty() }?.let {

--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/InfantRegistrationDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/InfantRegistrationDataset.kt
@@ -111,12 +111,13 @@ class InfantRegistrationDataset(
     private var weight = FormElement(
         id = 11,
         inputType = InputType.EDIT_TEXT,
-        title = "Weight at Birth(kg)",
+        title = "Weight at Birth(gram)",
         required = false,
         hasDependants = false,
-        minDecimal = 0.5,
-        maxDecimal = 7.0,
-        etInputType = android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL,
+        etMaxLength = 5,
+        min = 1,
+        max = 7000,
+        etInputType = android.text.InputType.TYPE_CLASS_NUMBER,
     )
 
     private var breastFeedingStarted = FormElement(
@@ -301,9 +302,7 @@ class InfantRegistrationDataset(
             }
 
             weight.id -> {
-                validateDoubleUpto1DecimalPlaces(weight)
-                if (weight.errorText == null) validateDoubleMinMax(weight)
-                -1
+                validateWeightOnEditText(weight)
 
             }
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/database/room/dao/BenDao.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/database/room/dao/BenDao.kt
@@ -203,12 +203,12 @@ interface BenDao {
         maxPncDate: Long = Konstants.pncEcGap
     ): Flow<List<BenWithDoAndPncCache>>
 
-    @Query("SELECT * FROM BEN_BASIC_CACHE WHERE CAST((strftime('%s','now') - dob/1000)/60/60/24/365 AS INTEGER) <= :max and villageId=:selectedVillage")
+    @Query("SELECT * FROM BEN_BASIC_CACHE WHERE CAST(((strftime('%s','now') - dob/1000)/60/60/24) AS INTEGER) <= :max and villageId=:selectedVillage")
     fun getAllInfantList(
         selectedVillage: Int, max: Int = Konstants.maxAgeForInfant
     ): Flow<List<BenBasicCache>>
 
-    @Query("SELECT * FROM BEN_BASIC_CACHE WHERE  CAST((strftime('%s','now') - dob/1000)/60/60/24/365 AS INTEGER) BETWEEN :min and :max and villageId=:selectedVillage")
+    @Query("SELECT * FROM BEN_BASIC_CACHE WHERE  CAST(((strftime('%s','now') - dob/1000)/60/60/24) AS INTEGER) BETWEEN :min and :max and villageId=:selectedVillage")
     fun getAllChildList(
         selectedVillage: Int,
         min: Int = Konstants.minAgeForChild,

--- a/app/src/main/java/org/piramalswasthya/sakhi/helpers/Konstants.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/helpers/Konstants.kt
@@ -26,9 +26,9 @@ object Konstants {
     const val minAgeForNcd: Int = 30
     const val minAgeForReproductiveAge: Int = 15
     const val maxAgeForReproductiveAge: Int = 49
-    const val maxAgeForInfant: Int = 1
-    const val minAgeForChild: Int = 2
-    const val maxAgeForChild: Int = 5
+    const val maxAgeForInfant: Int = 42
+    const val minAgeForChild: Int = 92
+    const val maxAgeForChild: Int = 456
     const val minAgeForAdolescent: Int = 6
     const val maxAgeForAdolescent: Int = 14
     const val maxAgeForCdr: Int = 14


### PR DESCRIPTION
Change the weight input field in the Infant Registration module from (Kg) to grams (gm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced validation for weight inputs in the infant registration process.
	- Updated weight input field title from "Weight at Birth(kg)" to "Weight at Birth(gram)" to reflect the new measurement unit.
	- Simplified validation logic for weight entry, improving user experience.
	- Adjusted age calculation logic to filter infants and children based on age in days rather than years.

- **Bug Fixes**
	- Ensured weight values are validated to prevent entries exceeding 7000 grams and to avoid empty or zero-only inputs.
	- Updated age constants for infants and children, refining age categorization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->