### PR TITLE
FLW-81 , Auto-Move Beneficiary to TB Suspected List Post-Suspected TB under NC…

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/cbac/CbacFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/cbac/CbacFragment.kt
@@ -98,8 +98,9 @@ class CbacFragment : Fragment() {
                     ).show()
                     WorkerUtils.triggerAmritPushWorker(requireContext())
                 }
-
-                else -> {}
+                else -> {
+                    Timber.d("IDLE!")
+                }
             }
         }
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/tb_screening/form/TBScreeningFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/tb_screening/form/TBScreeningFormViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -59,6 +60,8 @@ class TBScreeningFormViewModel @Inject constructor(
     var suspectedTBFamily: String? = null
 
     private lateinit var tbScreeningCache: TBScreeningCache
+
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.IO
 
     init {
         viewModelScope.launch {
@@ -117,7 +120,7 @@ class TBScreeningFormViewModel @Inject constructor(
 
     fun saveFormDirectlyfromCbac() {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
+            withContext(defaultDispatcher) {
                 try {
                     saveValues()
                     _state.postValue(State.SAVING)

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/tb_screening/form/TBScreeningFormViewModel.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/tb_screening/form/TBScreeningFormViewModel.kt
@@ -115,6 +115,34 @@ class TBScreeningFormViewModel @Inject constructor(
         }
     }
 
+    fun saveFormDirectlyfromCbac() {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                try {
+                    saveValues()
+                    _state.postValue(State.SAVING)
+                    tbRepo.saveTBScreening(tbScreeningCache)
+                    _state.postValue(State.SAVE_SUCCESS)
+                } catch (e: Exception) {
+                    Timber.d("saving tb screening data failed!!")
+                    _state.postValue(State.SAVE_FAILED)
+                }
+            }
+        }
+    }
+
+    private suspend fun saveValues() {
+        tbScreeningCache = TBScreeningCache(
+            benId = benRepo.getBenFromId(benId)!!.beneficiaryId,
+            coughMoreThan2Weeks = true,
+            lossOfWeight = true,
+            feverMoreThan2Weeks = true,
+            nightSweats = true,
+            bloodInSputum = true,
+            historyOfTb = true,
+        )
+    }
+
     fun resetState() {
         _state.value = State.IDLE
     }


### PR DESCRIPTION
…D Screening

## 📋 Description

FLW-81: 

When a beneficiary has completed NCD screening and is suspected of having TB, they should be automatically moved to the TB suspected list.
---

## ✅ Type of Change


- [ ] ✨ **Enhancement** 

---

## ℹ️ Additional Information

Beneficiaries flagged as suspected TB post-NCD screening should be automatically moved to the TB suspected list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced TB screening functionality within the non-communicable diseases section.
	- Added user alerts for TB suspicion and successful submission confirmations.
	- Enhanced data saving capabilities for TB screening forms directly from the CBAC context.

- **Bug Fixes**
	- Improved error handling during the TB screening data save process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->