### PR TITLE
FLW-82, FLW-75 - Spouse Sur Name Changes & Delivery Outcome Changes

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
@@ -1159,7 +1159,9 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
             if (hoFSpouse1.isEmpty()) {
                 firstName.value = hoFSpouse.genDetails?.spouseName
                 firstName.inputType = TEXT_VIEW
-                lastName.value = hoFSpouse.lastName
+                if (hoFSpouse.gender == Gender.MALE) {
+                    lastName.value = hoFSpouse.lastName
+                }
                 lastName.inputType = EDIT_TEXT
             }
             if (hoFSpouse.gender == FEMALE) {


### PR DESCRIPTION
## 📋 Description

JIRA ID: FLW-82, FLW-75

Spouse Sur Name was made blank in case the Head Of Family is the Wife.
Beneficiary moving to Delivery Outcome only if it is marked as delivered

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form handling for personal and family information, including conditional last name assignment for spouses based on gender.
	- Improved logic for displaying marital status and relation to head based on user input.

- **Bug Fixes**
	- Refined control flow for form population and validation processes, ensuring accurate data handling.

- **Refactor**
	- Updated method logic for better management of form data dependencies and age-related entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->