### PR TITLE
FLW-104,105

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/PregnantWomanRegistrationDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/PregnantWomanRegistrationDataset.kt
@@ -25,7 +25,7 @@ class PregnantWomanRegistrationDataset(
         var registrationDate:Long = 0
         private fun getMinLmpMillis(): Long {
             val cal = Calendar.getInstance()
-            cal.add(Calendar.DAY_OF_YEAR, -1 * 280)
+            cal.add(Calendar.DAY_OF_YEAR, -1 * 400) //before it is 280
             return cal.timeInMillis
         }
         private fun pwRegisterBeforeoneYear(): Long {
@@ -442,7 +442,7 @@ class PregnantWomanRegistrationDataset(
             isHrpCase
         )
 
-        dateOfReg.value = getDateFromLong(System.currentTimeMillis())
+      //  dateOfReg.value = getDateFromLong(System.currentTimeMillis())
         dateOfReg.value?.let {
             val long = getLongFromDate(it)
             dateOfhivTestDone.min = long - TimeUnit.DAYS.toMillis(365)
@@ -558,7 +558,7 @@ class PregnantWomanRegistrationDataset(
 
             it.dateOfRegistration.let {
                 lmp.max = it
-                lmp.min = it - TimeUnit.DAYS.toMillis(280)
+                lmp.min = it - TimeUnit.DAYS.toMillis(400)
                 dateOfVdrlTestDone.min = it - TimeUnit.DAYS.toMillis(365)
                 dateOfhivTestDone.min = it - TimeUnit.DAYS.toMillis(365)
                 dateOfhbsAgTestDone.min = it - TimeUnit.DAYS.toMillis(365)


### PR DESCRIPTION

-Set "Date of Registration" Field to Null by Default in "Pregnant Women Registration"but Mandatory

-The validation for the "Last Menstrual Period (LMP) Date" in the Pregnant Women Registration module currently allows a date up to 280 days prior to the registration date. This needs to be updated to allow a date up to 400 days prior to the registration date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Extended the allowable date range for last menstrual period (LMP) input from 280 days to 400 days prior to the current date.
	- Updated the minimum date for LMP field and associated tests based on the new LMP logic.

- **Bug Fixes**
	- Adjusted date calculations to ensure consistent validation across various date fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->