### PR TITLE
Marriage Age Validation Corrected for HoF & Edit Restrictions Applied

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
@@ -887,6 +887,7 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
             maritalStatus.value =
                 maritalStatus.getStringFromPosition(saved.genDetails?.maritalStatusId ?: 0)
             ageAtMarriage.value = calculateAgeAtMarriage(saved.dob, saved.genDetails?.marriageDate)?.toString()
+            ageAtMarriage.max = getAgeFromDob(saved.dob).toLong()
             dateOfMarriage.value = getDateFromLong(
                 saved.genDetails?.marriageDate ?: 0
             )

--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
@@ -853,9 +853,10 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
             lastName.value = saved.lastName
             agePopup.value = getDateFromLong(saved.dob)
             gender.value = gender.getStringFromPosition(saved.genderId)
-            if (ben.isSpouseAdded || ben.isChildrenAdded || ben.doYouHavechildren) {
+            if (ben.isSpouseAdded || ben.isChildrenAdded || ben.doYouHavechildren || !ben.genDetails?.spouseName.isNullOrEmpty()) {
                 gender.inputType = TEXT_VIEW
                 agePopup.inputType = TEXT_VIEW
+                maritalStatus.inputType = TEXT_VIEW
             }
             fatherName.value = saved.fatherName
             fileUploadFront.value = saved.kidDetails?.birthCertificateFileFrontView
@@ -1011,6 +1012,7 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
         agePopup.max = System.currentTimeMillis()
         if (relationToHeadId == 4 || relationToHeadId == 5) hoF?.let {
             isAddSpouse = true
+            agePopup.inputType = TEXT_VIEW
             gender.inputType = TEXT_VIEW
             maritalStatus.inputType = TEXT_VIEW
             setUpForSpouse(it, hoFSpouse,list)
@@ -1072,9 +1074,10 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
             agePopup.value = getDateFromLong(saved.dob)
             ageAtMarriage.max = getAgeFromDob(saved.dob).toLong()
             gender.value = gender.getStringFromPosition(saved.genderId)
-            if (ben.isSpouseAdded || ben.isChildrenAdded || ben.doYouHavechildren) {
+            if (ben.isSpouseAdded || ben.isChildrenAdded || ben.doYouHavechildren || !ben.genDetails?.spouseName.isNullOrEmpty()) {
                 gender.inputType = TEXT_VIEW
                 agePopup.inputType = TEXT_VIEW
+                maritalStatus.inputType = TEXT_VIEW
             }
             fatherName.value = saved.fatherName
             fileUploadFront.value = saved.kidDetails?.birthCertificateFileFrontView

--- a/app/src/main/res/values-as/strings_ben.xml
+++ b/app/src/main/res/values-as/strings_ben.xml
@@ -196,8 +196,9 @@
         <item>জীয়ৰী</item>
         <item>আইতা</item>
         <item>শাহুআই</item>
-        <item>নাতিনী</item>
+        <item>নাতিনী/নাতিনীয়েক</item>
         <item>বোৱাৰী</item>
+        <item>নবৌ/নন্দ</item>
         <item>অন্যান্য</item>
     </string-array>
 

--- a/app/src/main/res/values-hi/strings_ben.xml
+++ b/app/src/main/res/values-hi/strings_ben.xml
@@ -177,8 +177,9 @@
         <item>बेटी</item>
         <item>दादी</item>
         <item>सास</item>
-        <item>पोती</item>
-        <item>नातनी</item>
+        <item>पोती/नातनी</item>
+        <item>बहू</item>
+        <item>भाभी/नन्द/साली</item>
         <item>अन्य</item>
     </string-array>
 

--- a/app/src/main/res/values/strings_ben.xml
+++ b/app/src/main/res/values/strings_ben.xml
@@ -252,6 +252,7 @@
         <item>Mother in Law</item>
         <item>Grand Daughter</item>
         <item>Daughter in Law</item>
+        <item>Sister in Law</item>
         <item>Other</item>
     </string-array>
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: FLW-726, FLW-733

Marriage Age Validations corrected with respect to the Date of birth.
Edit restrictions are applied for dependent fields.
HoF Relations Added

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Age-at-marriage limits now use the beneficiary’s date of birth across forms, preventing invalid values when editing.
  * Marital-related fields (marital status, age-at-marriage, spouse-related inputs) now correctly show, hide or become read-only when a spouse name is present or when the relation indicates a spouse, improving form consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->