### PR TITLE
DatePickerDialog always be in english

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapter.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapter.kt
@@ -5,6 +5,7 @@ import android.app.TimePickerDialog
 import android.content.Context
 import android.content.Context.INPUT_METHOD_SERVICE
 import android.content.res.ColorStateList
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Color
 import android.net.Uri
@@ -70,6 +71,7 @@ import org.piramalswasthya.sakhi.model.InputType.TIME_PICKER
 import org.piramalswasthya.sakhi.model.InputType.values
 import org.piramalswasthya.sakhi.ui.home_activity.all_ben.new_ben_registration.AgePickerDialog
 import org.piramalswasthya.sakhi.ui.home_activity.all_ben.new_ben_registration.ben_form.NewBenRegViewModel.Companion.isOtpVerified
+import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import org.piramalswasthya.sakhi.utils.HelperUtil.getAgeStrFromAgeUnit
 import org.piramalswasthya.sakhi.utils.HelperUtil.getDobFromAge
 import org.piramalswasthya.sakhi.utils.HelperUtil.getLongFromDate
@@ -77,6 +79,7 @@ import org.piramalswasthya.sakhi.utils.HelperUtil.updateAgeDTO
 import org.piramalswasthya.sakhi.utils.Log
 import timber.log.Timber
 import java.util.Calendar
+import java.util.Locale
 
 
 class FormInputAdapter(
@@ -692,6 +695,17 @@ class FormInputAdapter(
             item.errorText?.also { binding.tilEditText.error = it }
                 ?: run { binding.tilEditText.error = null }
             binding.et.setOnClickListener {
+                val activity = binding.et.context.findFragmentActivity()
+                    ?: return@setOnClickListener
+                val originalLocale = Locale.getDefault()
+                Locale.setDefault(Locale.ENGLISH)
+                val config = Configuration(activity.resources.configuration)
+                config.setLocale(Locale.ENGLISH)
+                activity.resources.updateConfiguration(
+                    config,
+                    activity.resources.displayMetrics
+                )
+
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
                     thisMonth = value.substring(3, 5).trim().toInt() - 1
@@ -721,6 +735,15 @@ class FormInputAdapter(
                 if (item.showYearFirstInDatePicker)
                     datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
+                datePickerDialog.setOnDismissListener {
+                    Locale.setDefault(originalLocale)
+                    val restoreConfig = Configuration(activity.resources.configuration)
+                    restoreConfig.setLocale(originalLocale)
+                    activity.resources.updateConfiguration(
+                        restoreConfig,
+                        activity.resources.displayMetrics
+                    )
+                }
             }
             binding.executePendingBindings()
 
@@ -885,6 +908,17 @@ class FormInputAdapter(
             item.errorText?.also { binding.tilEditTextDate.error = it }
                 ?: run { binding.tilEditTextDate.error = null }
             binding.etDate.setOnClickListener {
+                val activity = binding.etDate.context.findFragmentActivity()
+                    ?: return@setOnClickListener
+                val originalLocale = Locale.getDefault()
+                Locale.setDefault(Locale.ENGLISH)
+                val config = Configuration(activity.resources.configuration)
+                config.setLocale(Locale.ENGLISH)
+                activity.resources.updateConfiguration(
+                    config,
+                    activity.resources.displayMetrics
+                )
+
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
                     thisMonth = value.substring(3, 5).trim().toInt() - 1
@@ -918,6 +952,15 @@ class FormInputAdapter(
                 if (item.showYearFirstInDatePicker)
                     datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
+                datePickerDialog.setOnDismissListener {
+                    Locale.setDefault(originalLocale)
+                    val restoreConfig = Configuration(activity.resources.configuration)
+                    restoreConfig.setLocale(originalLocale)
+                    activity.resources.updateConfiguration(
+                        restoreConfig,
+                        activity.resources.displayMetrics
+                    )
+                }
             }
             binding.executePendingBindings()
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapter.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapter.kt
@@ -5,7 +5,6 @@ import android.app.TimePickerDialog
 import android.content.Context
 import android.content.Context.INPUT_METHOD_SERVICE
 import android.content.res.ColorStateList
-import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Color
 import android.net.Uri
@@ -71,12 +70,12 @@ import org.piramalswasthya.sakhi.model.InputType.TIME_PICKER
 import org.piramalswasthya.sakhi.model.InputType.values
 import org.piramalswasthya.sakhi.ui.home_activity.all_ben.new_ben_registration.AgePickerDialog
 import org.piramalswasthya.sakhi.ui.home_activity.all_ben.new_ben_registration.ben_form.NewBenRegViewModel.Companion.isOtpVerified
+import org.piramalswasthya.sakhi.utils.HelperUtil
 import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import org.piramalswasthya.sakhi.utils.HelperUtil.getAgeStrFromAgeUnit
 import org.piramalswasthya.sakhi.utils.HelperUtil.getDobFromAge
 import org.piramalswasthya.sakhi.utils.HelperUtil.getLongFromDate
 import org.piramalswasthya.sakhi.utils.HelperUtil.updateAgeDTO
-import org.piramalswasthya.sakhi.utils.Log
 import timber.log.Timber
 import java.util.Calendar
 import java.util.Locale
@@ -698,13 +697,7 @@ class FormInputAdapter(
                 val activity = binding.et.context.findFragmentActivity()
                     ?: return@setOnClickListener
                 val originalLocale = Locale.getDefault()
-                Locale.setDefault(Locale.ENGLISH)
-                val config = Configuration(activity.resources.configuration)
-                config.setLocale(Locale.ENGLISH)
-                activity.resources.updateConfiguration(
-                    config,
-                    activity.resources.displayMetrics
-                )
+                HelperUtil.setEnLocaleForDatePicker(activity)
 
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
@@ -736,13 +729,7 @@ class FormInputAdapter(
                     datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
                 datePickerDialog.setOnDismissListener {
-                    Locale.setDefault(originalLocale)
-                    val restoreConfig = Configuration(activity.resources.configuration)
-                    restoreConfig.setLocale(originalLocale)
-                    activity.resources.updateConfiguration(
-                        restoreConfig,
-                        activity.resources.displayMetrics
-                    )
+                    HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
                 }
             }
             binding.executePendingBindings()
@@ -911,13 +898,7 @@ class FormInputAdapter(
                 val activity = binding.etDate.context.findFragmentActivity()
                     ?: return@setOnClickListener
                 val originalLocale = Locale.getDefault()
-                Locale.setDefault(Locale.ENGLISH)
-                val config = Configuration(activity.resources.configuration)
-                config.setLocale(Locale.ENGLISH)
-                activity.resources.updateConfiguration(
-                    config,
-                    activity.resources.displayMetrics
-                )
+                HelperUtil.setEnLocaleForDatePicker(activity)
 
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
@@ -953,13 +934,7 @@ class FormInputAdapter(
                     datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
                 datePickerDialog.setOnDismissListener {
-                    Locale.setDefault(originalLocale)
-                    val restoreConfig = Configuration(activity.resources.configuration)
-                    restoreConfig.setLocale(originalLocale)
-                    activity.resources.updateConfiguration(
-                        restoreConfig,
-                        activity.resources.displayMetrics
-                    )
+                    HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
                 }
             }
             binding.executePendingBindings()

--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterOld.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterOld.kt
@@ -2,6 +2,7 @@ package org.piramalswasthya.sakhi.adapters
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.CountDownTimer
 import android.text.Editable
@@ -57,8 +58,10 @@ import org.piramalswasthya.sakhi.model.InputType.TIME_PICKER
 import org.piramalswasthya.sakhi.model.InputType.NUMBER_PICKER
 
 import org.piramalswasthya.sakhi.model.InputType.values
+import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import timber.log.Timber
 import java.util.Calendar
+import java.util.Locale
 
 class FormInputAdapterOld(
     private val imageClickListener: ImageClickListener? = null,
@@ -508,6 +511,17 @@ class FormInputAdapterOld(
             item.errorText?.also { binding.tilEditText.error = it }
                 ?: run { binding.tilEditText.error = null }
             binding.et.setOnClickListener {
+                val activity = binding.et.context.findFragmentActivity()
+                    ?: return@setOnClickListener
+                val originalLocale = Locale.getDefault()
+                Locale.setDefault(Locale.ENGLISH)
+                val config = Configuration(activity.resources.configuration)
+                config.setLocale(Locale.ENGLISH)
+                activity.resources.updateConfiguration(
+                    config,
+                    activity.resources.displayMetrics
+                )
+
                 item.value.value?.let { value ->
                     thisYear = value.substring(6).toInt()
                     thisMonth = value.substring(3, 5).trim().toInt() - 1
@@ -527,6 +541,15 @@ class FormInputAdapterOld(
                 datePickerDialog.datePicker.minDate = item.min ?: 0
                 datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
+                datePickerDialog.setOnDismissListener {
+                    Locale.setDefault(originalLocale)
+                    val restoreConfig = Configuration(activity.resources.configuration)
+                    restoreConfig.setLocale(originalLocale)
+                    activity.resources.updateConfiguration(
+                        restoreConfig,
+                        activity.resources.displayMetrics
+                    )
+                }
             }
             binding.executePendingBindings()
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterOld.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterOld.kt
@@ -2,7 +2,6 @@ package org.piramalswasthya.sakhi.adapters
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
-import android.content.res.Configuration
 import android.net.Uri
 import android.os.CountDownTimer
 import android.text.Editable
@@ -56,8 +55,8 @@ import org.piramalswasthya.sakhi.model.InputType.RADIO
 import org.piramalswasthya.sakhi.model.InputType.TEXT_VIEW
 import org.piramalswasthya.sakhi.model.InputType.TIME_PICKER
 import org.piramalswasthya.sakhi.model.InputType.NUMBER_PICKER
-
 import org.piramalswasthya.sakhi.model.InputType.values
+import org.piramalswasthya.sakhi.utils.HelperUtil
 import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import timber.log.Timber
 import java.util.Calendar
@@ -514,13 +513,7 @@ class FormInputAdapterOld(
                 val activity = binding.et.context.findFragmentActivity()
                     ?: return@setOnClickListener
                 val originalLocale = Locale.getDefault()
-                Locale.setDefault(Locale.ENGLISH)
-                val config = Configuration(activity.resources.configuration)
-                config.setLocale(Locale.ENGLISH)
-                activity.resources.updateConfiguration(
-                    config,
-                    activity.resources.displayMetrics
-                )
+                HelperUtil.setEnLocaleForDatePicker(activity)
 
                 item.value.value?.let { value ->
                     thisYear = value.substring(6).toInt()
@@ -542,13 +535,7 @@ class FormInputAdapterOld(
                 datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
                 datePickerDialog.setOnDismissListener {
-                    Locale.setDefault(originalLocale)
-                    val restoreConfig = Configuration(activity.resources.configuration)
-                    restoreConfig.setLocale(originalLocale)
-                    activity.resources.updateConfiguration(
-                        restoreConfig,
-                        activity.resources.displayMetrics
-                    )
+                    HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
                 }
             }
             binding.executePendingBindings()

--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterWithBgIcon.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterWithBgIcon.kt
@@ -4,6 +4,7 @@ import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Context.INPUT_METHOD_SERVICE
 import android.content.res.ColorStateList
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Color
 import android.net.Uri
@@ -67,12 +68,14 @@ import org.piramalswasthya.sakhi.model.InputType.TEXT_VIEW
 import org.piramalswasthya.sakhi.model.InputType.TIME_PICKER
 import org.piramalswasthya.sakhi.model.InputType.values
 import org.piramalswasthya.sakhi.ui.home_activity.all_ben.new_ben_registration.AgePickerDialog
+import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import org.piramalswasthya.sakhi.utils.HelperUtil.getAgeStrFromAgeUnit
 import org.piramalswasthya.sakhi.utils.HelperUtil.getDobFromAge
 import org.piramalswasthya.sakhi.utils.HelperUtil.getLongFromDate
 import org.piramalswasthya.sakhi.utils.HelperUtil.updateAgeDTO
 import timber.log.Timber
 import java.util.Calendar
+import java.util.Locale
 
 class FormInputAdapterWithBgIcon (
     private val imageClickListener: ImageClickListener? = null,
@@ -506,6 +509,17 @@ class FormInputAdapterWithBgIcon (
             item.errorText?.also { binding.tilEditText.error = it }
                 ?: run { binding.tilEditText.error = null }
             binding.et.setOnClickListener {
+                val activity = binding.et.context.findFragmentActivity()
+                    ?: return@setOnClickListener
+                val originalLocale = Locale.getDefault()
+                Locale.setDefault(Locale.ENGLISH)
+                val config = Configuration(activity.resources.configuration)
+                config.setLocale(Locale.ENGLISH)
+                activity.resources.updateConfiguration(
+                    config,
+                    activity.resources.displayMetrics
+                )
+
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
                     thisMonth = value.substring(3, 5).trim().toInt() - 1
@@ -539,8 +553,23 @@ class FormInputAdapterWithBgIcon (
                     datePickerDialog.show()
                 }else{
                     Toast.makeText(binding.root.context,"Something went wrong",Toast.LENGTH_SHORT).show()
+                    Locale.setDefault(originalLocale)
+                    val restoreConfig = Configuration(activity.resources.configuration)
+                    restoreConfig.setLocale(originalLocale)
+                    activity.resources.updateConfiguration(
+                        restoreConfig,
+                        activity.resources.displayMetrics
+                    )
                 }
-
+                datePickerDialog.setOnDismissListener {
+                    Locale.setDefault(originalLocale)
+                    val restoreConfig = Configuration(activity.resources.configuration)
+                    restoreConfig.setLocale(originalLocale)
+                    activity.resources.updateConfiguration(
+                        restoreConfig,
+                        activity.resources.displayMetrics
+                    )
+                }
             }
             binding.executePendingBindings()
 
@@ -1028,6 +1057,17 @@ class FormInputAdapterWithBgIcon (
             item.errorText?.also { binding.tilEditTextDate.error = it }
                 ?: run { binding.tilEditTextDate.error = null }
             binding.etDate.setOnClickListener {
+                val activity = binding.etDate.context.findFragmentActivity()
+                    ?: return@setOnClickListener
+                val originalLocale = Locale.getDefault()
+                Locale.setDefault(Locale.ENGLISH)
+                val config = Configuration(activity.resources.configuration)
+                config.setLocale(Locale.ENGLISH)
+                activity.resources.updateConfiguration(
+                    config,
+                    activity.resources.displayMetrics
+                )
+
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
                     thisMonth = value.substring(3, 5).trim().toInt() - 1
@@ -1061,6 +1101,15 @@ class FormInputAdapterWithBgIcon (
                 if (item.showYearFirstInDatePicker)
                     datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
+                datePickerDialog.setOnDismissListener {
+                    Locale.setDefault(originalLocale)
+                    val restoreConfig = Configuration(activity.resources.configuration)
+                    restoreConfig.setLocale(originalLocale)
+                    activity.resources.updateConfiguration(
+                        restoreConfig,
+                        activity.resources.displayMetrics
+                    )
+                }
             }
             binding.executePendingBindings()
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterWithBgIcon.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/FormInputAdapterWithBgIcon.kt
@@ -4,7 +4,6 @@ import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Context.INPUT_METHOD_SERVICE
 import android.content.res.ColorStateList
-import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Color
 import android.net.Uri
@@ -52,7 +51,6 @@ import org.piramalswasthya.sakhi.helpers.Konstants
 import org.piramalswasthya.sakhi.helpers.getDateString
 import org.piramalswasthya.sakhi.model.AgeUnitDTO
 import org.piramalswasthya.sakhi.model.FormElement
-import org.piramalswasthya.sakhi.model.FormInputOld
 import org.piramalswasthya.sakhi.model.InputType
 import org.piramalswasthya.sakhi.model.InputType.AGE_PICKER
 import org.piramalswasthya.sakhi.model.InputType.BUTTON
@@ -68,6 +66,7 @@ import org.piramalswasthya.sakhi.model.InputType.TEXT_VIEW
 import org.piramalswasthya.sakhi.model.InputType.TIME_PICKER
 import org.piramalswasthya.sakhi.model.InputType.values
 import org.piramalswasthya.sakhi.ui.home_activity.all_ben.new_ben_registration.AgePickerDialog
+import org.piramalswasthya.sakhi.utils.HelperUtil
 import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import org.piramalswasthya.sakhi.utils.HelperUtil.getAgeStrFromAgeUnit
 import org.piramalswasthya.sakhi.utils.HelperUtil.getDobFromAge
@@ -86,7 +85,6 @@ class FormInputAdapterWithBgIcon (
     private val isEnabled: Boolean = true
 ) : ListAdapter<FormElement, ViewHolder>(FormInputDiffCallBack) {
 
-
     object FormInputDiffCallBack : DiffUtil.ItemCallback<FormElement>() {
         override fun areItemsTheSame(oldItem: FormElement, newItem: FormElement) =
             oldItem.id == newItem.id
@@ -96,8 +94,6 @@ class FormInputAdapterWithBgIcon (
             return oldItem.errorText == newItem.errorText
         }
     }
-
-
 
     class EditTextInputViewHolder private constructor(private val binding: RvItemFormEditTextWithBgIconBinding) :
         ViewHolder(binding.root) {
@@ -512,13 +508,7 @@ class FormInputAdapterWithBgIcon (
                 val activity = binding.et.context.findFragmentActivity()
                     ?: return@setOnClickListener
                 val originalLocale = Locale.getDefault()
-                Locale.setDefault(Locale.ENGLISH)
-                val config = Configuration(activity.resources.configuration)
-                config.setLocale(Locale.ENGLISH)
-                activity.resources.updateConfiguration(
-                    config,
-                    activity.resources.displayMetrics
-                )
+                HelperUtil.setEnLocaleForDatePicker(activity)
 
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
@@ -553,22 +543,10 @@ class FormInputAdapterWithBgIcon (
                     datePickerDialog.show()
                 }else{
                     Toast.makeText(binding.root.context,"Something went wrong",Toast.LENGTH_SHORT).show()
-                    Locale.setDefault(originalLocale)
-                    val restoreConfig = Configuration(activity.resources.configuration)
-                    restoreConfig.setLocale(originalLocale)
-                    activity.resources.updateConfiguration(
-                        restoreConfig,
-                        activity.resources.displayMetrics
-                    )
+                    HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
                 }
                 datePickerDialog.setOnDismissListener {
-                    Locale.setDefault(originalLocale)
-                    val restoreConfig = Configuration(activity.resources.configuration)
-                    restoreConfig.setLocale(originalLocale)
-                    activity.resources.updateConfiguration(
-                        restoreConfig,
-                        activity.resources.displayMetrics
-                    )
+                    HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
                 }
             }
             binding.executePendingBindings()
@@ -1060,13 +1038,7 @@ class FormInputAdapterWithBgIcon (
                 val activity = binding.etDate.context.findFragmentActivity()
                     ?: return@setOnClickListener
                 val originalLocale = Locale.getDefault()
-                Locale.setDefault(Locale.ENGLISH)
-                val config = Configuration(activity.resources.configuration)
-                config.setLocale(Locale.ENGLISH)
-                activity.resources.updateConfiguration(
-                    config,
-                    activity.resources.displayMetrics
-                )
+                HelperUtil.setEnLocaleForDatePicker(activity)
 
                 item.value?.let { value ->
                     thisYear = value.substring(6).toInt()
@@ -1102,13 +1074,7 @@ class FormInputAdapterWithBgIcon (
                     datePickerDialog.datePicker.touchables[0].performClick()
                 datePickerDialog.show()
                 datePickerDialog.setOnDismissListener {
-                    Locale.setDefault(originalLocale)
-                    val restoreConfig = Configuration(activity.resources.configuration)
-                    restoreConfig.setLocale(originalLocale)
-                    activity.resources.updateConfiguration(
-                        restoreConfig,
-                        activity.resources.displayMetrics
-                    )
+                    HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
                 }
             }
             binding.executePendingBindings()

--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/dynamicAdapter/FormRendererAdapter.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/dynamicAdapter/FormRendererAdapter.kt
@@ -4,7 +4,6 @@
     import android.app.DatePickerDialog
     import android.content.ActivityNotFoundException
     import android.content.Intent
-    import android.content.res.Configuration
     import android.graphics.BitmapFactory
     import android.graphics.Color
     import android.graphics.Typeface
@@ -29,6 +28,7 @@
     import kotlinx.coroutines.launch
     import org.piramalswasthya.sakhi.R
     import org.piramalswasthya.sakhi.configuration.dynamicDataSet.FormField
+    import org.piramalswasthya.sakhi.utils.HelperUtil
     import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
     import org.piramalswasthya.sakhi.utils.dynamicFormConstants.FormConstants
     import timber.log.Timber
@@ -668,14 +668,7 @@
                                 val activity = editText.context.findFragmentActivity()
                                     ?: return@setOnClickListener
                                 val originalLocale = Locale.getDefault()
-                                Locale.setDefault(Locale.ENGLISH)
-                                val config = Configuration(activity.resources.configuration)
-                                config.setLocale(Locale.ENGLISH)
-                                activity.resources.updateConfiguration(
-                                    config,
-                                    activity.resources.displayMetrics
-                                )
-
+                                HelperUtil.setEnLocaleForDatePicker(activity)
 
                                 val calendar = Calendar.getInstance()
 
@@ -913,13 +906,7 @@
                                     }
 
                                     setOnDismissListener {
-                                        Locale.setDefault(originalLocale)
-                                        val restoreConfig = Configuration(activity.resources.configuration)
-                                        restoreConfig.setLocale(originalLocale)
-                                        activity.resources.updateConfiguration(
-                                            restoreConfig,
-                                            activity.resources.displayMetrics
-                                        )
+                                        HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
                                     }
 
                                 }.show()

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/abha_id_activity/aadhaar_id/aadhaar_num_gov/AadhaarNumberGovFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/abha_id_activity/aadhaar_id/aadhaar_num_gov/AadhaarNumberGovFragment.kt
@@ -1,6 +1,7 @@
 package org.piramalswasthya.sakhi.ui.abha_id_activity.aadhaar_id.aadhaar_num_gov
 
 import android.app.DatePickerDialog
+import android.content.res.Configuration
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -14,7 +15,9 @@ import com.google.gson.Gson
 import dagger.hilt.android.AndroidEntryPoint
 import org.piramalswasthya.sakhi.databinding.FragmentAadhaarNumberGovBinding
 import org.piramalswasthya.sakhi.ui.abha_id_activity.aadhaar_id.AadhaarIdViewModel
+import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import java.util.Calendar
+import java.util.Locale
 
 @AndroidEntryPoint
 class AadhaarNumberGovFragment : Fragment() {
@@ -95,6 +98,17 @@ class AadhaarNumberGovFragment : Fragment() {
         val today = Calendar.getInstance()
 
         binding.dateEt.setOnClickListener {
+            val activity = binding.dateEt.context.findFragmentActivity()
+                ?: return@setOnClickListener
+            val originalLocale = Locale.getDefault()
+            Locale.setDefault(Locale.ENGLISH)
+            val config = Configuration(activity.resources.configuration)
+            config.setLocale(Locale.ENGLISH)
+            activity.resources.updateConfiguration(
+                config,
+                activity.resources.displayMetrics
+            )
+
             val datePickerDialog = DatePickerDialog(
                 it.context,
                 { _, year, month, day ->
@@ -108,6 +122,15 @@ class AadhaarNumberGovFragment : Fragment() {
             )
             binding.tilEditText.error = null
             datePickerDialog.show()
+            datePickerDialog.setOnDismissListener {
+                Locale.setDefault(originalLocale)
+                val restoreConfig = Configuration(activity.resources.configuration)
+                restoreConfig.setLocale(originalLocale)
+                activity.resources.updateConfiguration(
+                    restoreConfig,
+                    activity.resources.displayMetrics
+                )
+            }
             checkValidity()
         }
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/abha_id_activity/aadhaar_id/aadhaar_num_gov/AadhaarNumberGovFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/abha_id_activity/aadhaar_id/aadhaar_num_gov/AadhaarNumberGovFragment.kt
@@ -1,7 +1,6 @@
 package org.piramalswasthya.sakhi.ui.abha_id_activity.aadhaar_id.aadhaar_num_gov
 
 import android.app.DatePickerDialog
-import android.content.res.Configuration
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -15,6 +14,7 @@ import com.google.gson.Gson
 import dagger.hilt.android.AndroidEntryPoint
 import org.piramalswasthya.sakhi.databinding.FragmentAadhaarNumberGovBinding
 import org.piramalswasthya.sakhi.ui.abha_id_activity.aadhaar_id.AadhaarIdViewModel
+import org.piramalswasthya.sakhi.utils.HelperUtil
 import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import java.util.Calendar
 import java.util.Locale
@@ -101,13 +101,7 @@ class AadhaarNumberGovFragment : Fragment() {
             val activity = binding.dateEt.context.findFragmentActivity()
                 ?: return@setOnClickListener
             val originalLocale = Locale.getDefault()
-            Locale.setDefault(Locale.ENGLISH)
-            val config = Configuration(activity.resources.configuration)
-            config.setLocale(Locale.ENGLISH)
-            activity.resources.updateConfiguration(
-                config,
-                activity.resources.displayMetrics
-            )
+            HelperUtil.setEnLocaleForDatePicker(activity)
 
             val datePickerDialog = DatePickerDialog(
                 it.context,
@@ -123,13 +117,7 @@ class AadhaarNumberGovFragment : Fragment() {
             binding.tilEditText.error = null
             datePickerDialog.show()
             datePickerDialog.setOnDismissListener {
-                Locale.setDefault(originalLocale)
-                val restoreConfig = Configuration(activity.resources.configuration)
-                restoreConfig.setLocale(originalLocale)
-                activity.resources.updateConfiguration(
-                    restoreConfig,
-                    activity.resources.displayMetrics
-                )
+                HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
             }
             checkValidity()
         }

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/asha_supervisor/supervisor/SupervisorFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/asha_supervisor/supervisor/SupervisorFragment.kt
@@ -1,13 +1,9 @@
 package org.piramalswasthya.sakhi.ui.asha_supervisor.supervisor
 
-import android.app.DatePickerDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ArrayAdapter
-import android.widget.Spinner
-import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -16,27 +12,20 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkQuery
-import com.google.android.material.datepicker.CalendarConstraints
-import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import org.piramalswasthya.sakhi.R
 import org.piramalswasthya.sakhi.adapters.IconGridAdapter
 import org.piramalswasthya.sakhi.configuration.IconDataset
 import org.piramalswasthya.sakhi.databinding.FragmentSupervisorBinding
-import org.piramalswasthya.sakhi.helpers.Konstants
 import org.piramalswasthya.sakhi.helpers.Languages
 import org.piramalswasthya.sakhi.helpers.Languages.ASSAMESE
 import org.piramalswasthya.sakhi.helpers.Languages.ENGLISH
-import org.piramalswasthya.sakhi.helpers.getDateString
 import org.piramalswasthya.sakhi.ui.asha_supervisor.SupervisorActivity
-import org.piramalswasthya.sakhi.ui.home_activity.home.EnableDevModeBottomSheetFragment
 import org.piramalswasthya.sakhi.ui.service_location_activity.ServiceTypeViewModel
-import org.piramalswasthya.sakhi.utils.MonthYearPickerDialog
 import org.piramalswasthya.sakhi.work.PullFromAmritWorker
 import org.piramalswasthya.sakhi.work.WorkerUtils
 import timber.log.Timber
-import java.util.Calendar
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/cbac/CbacFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/cbac/CbacFragment.kt
@@ -2,6 +2,7 @@ package org.piramalswasthya.sakhi.ui.home_activity.non_communicable_diseases.cba
 
 import android.app.AlertDialog
 import android.app.DatePickerDialog
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -25,6 +26,7 @@ import org.piramalswasthya.sakhi.model.ReferalCache
 import org.piramalswasthya.sakhi.ui.home_activity.HomeActivity
 import org.piramalswasthya.sakhi.ui.home_activity.disease_control.leprosy.form.LeprosyFormViewModel
 import org.piramalswasthya.sakhi.ui.home_activity.non_communicable_diseases.tb_screening.form.TBScreeningFormViewModel
+import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import org.piramalswasthya.sakhi.work.WorkerUtils
 import timber.log.Timber
 import java.text.SimpleDateFormat
@@ -637,6 +639,16 @@ class CbacFragment : Fragment() {
         val thisMonth = today.get(Calendar.MONTH)
         val thisDay = today.get(Calendar.DAY_OF_MONTH)
         binding.etDate.setOnClickListener {
+            val activity = binding.etDate.context.findFragmentActivity()
+                ?: return@setOnClickListener
+            val originalLocale = Locale.getDefault()
+            Locale.setDefault(Locale.ENGLISH)
+            val config = Configuration(activity.resources.configuration)
+            config.setLocale(Locale.ENGLISH)
+            activity.resources.updateConfiguration(
+                config,
+                activity.resources.displayMetrics
+            )
 
             val datePickerDialog = DatePickerDialog(
                 it.context, { _, year, month, day ->
@@ -652,6 +664,15 @@ class CbacFragment : Fragment() {
 
             }
             datePickerDialog.show()
+            datePickerDialog.setOnDismissListener {
+                Locale.setDefault(originalLocale)
+                val restoreConfig = Configuration(activity.resources.configuration)
+                restoreConfig.setLocale(originalLocale)
+                activity.resources.updateConfiguration(
+                    restoreConfig,
+                    activity.resources.displayMetrics
+                )
+            }
         }
         setupRaFill()
         setupEdFill()

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/cbac/CbacFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/non_communicable_diseases/cbac/CbacFragment.kt
@@ -2,7 +2,6 @@ package org.piramalswasthya.sakhi.ui.home_activity.non_communicable_diseases.cba
 
 import android.app.AlertDialog
 import android.app.DatePickerDialog
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -26,6 +25,7 @@ import org.piramalswasthya.sakhi.model.ReferalCache
 import org.piramalswasthya.sakhi.ui.home_activity.HomeActivity
 import org.piramalswasthya.sakhi.ui.home_activity.disease_control.leprosy.form.LeprosyFormViewModel
 import org.piramalswasthya.sakhi.ui.home_activity.non_communicable_diseases.tb_screening.form.TBScreeningFormViewModel
+import org.piramalswasthya.sakhi.utils.HelperUtil
 import org.piramalswasthya.sakhi.utils.HelperUtil.findFragmentActivity
 import org.piramalswasthya.sakhi.work.WorkerUtils
 import timber.log.Timber
@@ -642,13 +642,7 @@ class CbacFragment : Fragment() {
             val activity = binding.etDate.context.findFragmentActivity()
                 ?: return@setOnClickListener
             val originalLocale = Locale.getDefault()
-            Locale.setDefault(Locale.ENGLISH)
-            val config = Configuration(activity.resources.configuration)
-            config.setLocale(Locale.ENGLISH)
-            activity.resources.updateConfiguration(
-                config,
-                activity.resources.displayMetrics
-            )
+            HelperUtil.setEnLocaleForDatePicker(activity)
 
             val datePickerDialog = DatePickerDialog(
                 it.context, { _, year, month, day ->
@@ -665,13 +659,7 @@ class CbacFragment : Fragment() {
             }
             datePickerDialog.show()
             datePickerDialog.setOnDismissListener {
-                Locale.setDefault(originalLocale)
-                val restoreConfig = Configuration(activity.resources.configuration)
-                restoreConfig.setLocale(originalLocale)
-                activity.resources.updateConfiguration(
-                    restoreConfig,
-                    activity.resources.displayMetrics
-                )
+                HelperUtil.setOriginalLocaleForDatePicker(activity,originalLocale)
             }
         }
         setupRaFill()

--- a/app/src/main/java/org/piramalswasthya/sakhi/utils/HelperUtil.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/utils/HelperUtil.kt
@@ -63,6 +63,26 @@ object HelperUtil {
         return null
     }
 
+    fun setEnLocaleForDatePicker(activity: FragmentActivity){
+        Locale.setDefault(Locale.ENGLISH)
+        val config = Configuration(activity.resources.configuration)
+        config.setLocale(Locale.ENGLISH)
+        activity.resources.updateConfiguration(
+            config,
+            activity.resources.displayMetrics
+        )
+    }
+
+    fun setOriginalLocaleForDatePicker(activity: FragmentActivity, originalLocale: Locale){
+        Locale.setDefault(originalLocale)
+        val restoreConfig = Configuration(activity.resources.configuration)
+        restoreConfig.setLocale(originalLocale)
+        activity.resources.updateConfiguration(
+            restoreConfig,
+            activity.resources.displayMetrics
+        )
+    }
+
 
     private val dateFormat = SimpleDateFormat("EEE, MMM dd yyyy", Locale.ENGLISH)
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/utils/HelperUtil.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/utils/HelperUtil.kt
@@ -3,6 +3,7 @@ import android.app.AlertDialog
 import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.content.res.Configuration
 import android.content.res.Resources
@@ -31,6 +32,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.collection.lruCache
 import androidx.core.content.FileProvider
 import androidx.core.graphics.withTranslation
+import androidx.fragment.app.FragmentActivity
 import com.bumptech.glide.Glide
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.json.JSONArray
@@ -51,6 +53,16 @@ import java.util.Date
 import java.util.Locale
 
 object HelperUtil {
+
+    fun Context.findFragmentActivity(): FragmentActivity? {
+        var ctx = this
+        while (ctx is ContextWrapper) {
+            if (ctx is FragmentActivity) return ctx
+            ctx = ctx.baseContext
+        }
+        return null
+    }
+
 
     private val dateFormat = SimpleDateFormat("EEE, MMM dd yyyy", Locale.ENGLISH)
 
@@ -243,7 +255,7 @@ object HelperUtil {
 
     fun parseDateToMillis(dateStr: String): Long {
         return try {
-            val sdf = SimpleDateFormat("dd-MM-yyyy", Locale.getDefault())
+            val sdf = SimpleDateFormat("dd-MM-yyyy", Locale.ENGLISH)
             sdf.isLenient = false
             sdf.parse(dateStr)?.time ?: 0L
         } catch (e: Exception) {


### PR DESCRIPTION
In this branch, the functionality has been implemented so that regardless of the language selected by the user, the date picker dialog is always displayed in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date picker functionality by ensuring consistent English locale handling during date selection across the app.

* **Refactor**
  * Enhanced locale management for date-related operations to provide more reliable date entry and formatting.
  * Added utility enhancements for activity context retrieval.

* **Chores**
  * Cleaned up unused imports to reduce code clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->