### PR TITLE
fix: show age and DoB as separate read-only fields in beneficiary edit

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/BenRegFormDataset.kt
@@ -90,6 +90,13 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
             return cal.timeInMillis
         }
 
+        private fun getAgeStringFromDob(dob: Long): String {
+            val cal = Calendar.getInstance()
+            cal.timeInMillis = dob
+            val ageUnitDTO = org.piramalswasthya.sakhi.model.AgeUnitDTO(0, 0, 0)
+            org.piramalswasthya.sakhi.utils.HelperUtil.updateAgeDTO(ageUnitDTO, cal)
+            return org.piramalswasthya.sakhi.utils.HelperUtil.getAgeStrFromAgeUnit(ageUnitDTO)
+        }
     }
 
     private var familyHeadPhoneNo: String? = null
@@ -157,6 +164,13 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
         hasDependants = true,
         etInputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_NORMAL
     )
+    private val dobReadOnly = FormElement(
+        id = 116,
+        inputType = TEXT_VIEW,
+        title = resources.getString(R.string.nbr_dob),
+        required = false,
+    )
+
     val gender = FormElement(
         id = 9,
         inputType = RADIO,
@@ -870,6 +884,9 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
             if (ben.isSpouseAdded || ben.isChildrenAdded || ben.doYouHavechildren || !ben.genDetails?.spouseName.isNullOrEmpty()) {
                 gender.inputType = TEXT_VIEW
                 agePopup.inputType = TEXT_VIEW
+                agePopup.value = getAgeStringFromDob(saved.dob)
+                dobReadOnly.value = getDateFromLong(saved.dob)
+                list.add(list.indexOf(agePopup) + 1, dobReadOnly)
                 maritalStatus.inputType = TEXT_VIEW
             }
             fatherName.value = saved.fatherName
@@ -1106,6 +1123,9 @@ class BenRegFormDataset(context: Context, language: Languages) : Dataset(context
             if (ben.isSpouseAdded || ben.isChildrenAdded || ben.doYouHavechildren || !ben.genDetails?.spouseName.isNullOrEmpty()) {
                 gender.inputType = TEXT_VIEW
                 agePopup.inputType = TEXT_VIEW
+                agePopup.value = getAgeStringFromDob(saved.dob)
+                dobReadOnly.value = getDateFromLong(saved.dob)
+                list.add(list.indexOf(agePopup) + 1, dobReadOnly)
                 maritalStatus.inputType = TEXT_VIEW
             }
             fatherName.value = saved.fatherName


### PR DESCRIPTION
## 📋 Description

JIRA ID: FLW-868

## Summary
  - When editing a married beneficiary with spouse/children, the Age field was displaying
    DoB value instead of actual age
  - Added a separate read-only DoB field alongside the Age field, matching the editable view layout
  - Age field now shows computed age (e.g. "25 Years, 3 Months") and DoB field shows date (e.g. "05-04-2001")
  - Applied to both Head of Family and Family Member edit flows

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## Test Plan
  - [ ] Edit a married beneficiary with spouse — verify "Age" shows age string and "Date of Birth" shows date
  - [ ] Edit a beneficiary without spouse — verify editable AGE_PICKER works as before with both fields
  - [ ] Test for both HoF and family member edit paths