### PR TITLE
fix: Hindi language support — validation errors, form dropdowns, and app name

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/configuration/Dataset.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/configuration/Dataset.kt
@@ -685,7 +685,7 @@ abstract class Dataset(context: Context, val currentLanguage: Languages) {
 
     protected fun validateAllAlphabetsSpecialAndNumericOnEditText(formElement: FormElement): Int {
         formElement.value?.takeIf { it.isNotEmpty() }?.let { input ->
-            val regex = "^[\\p{L}0-9\\s\\p{Punct}]+$".toRegex() // allows Unicode letters, numbers, spaces, and special characters
+            val regex = "^[\\p{L}\\p{M}0-9\\s\\p{Punct}]+$".toRegex() // allows Unicode letters, combining marks (vowel signs, anusvara, nukta), numbers, spaces, and special characters
 
             val isValid = regex.matches(input)
             if (!isValid) {

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/all_ben/ben_ifa/BenIfaFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/all_ben/ben_ifa/BenIfaFormFragment.kt
@@ -242,7 +242,7 @@ class BenIfaFormFragment : Fragment() {
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
 
-                    val result = FieldValidator.validate(updated, null)
+                    val result = FieldValidator.validate(updated, null, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
                     if (schemaField.fieldId == "visit_date" && schemaField.value is String) {

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/all_ben/eye_surgery_registration/EyeSurgeryFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/all_ben/eye_surgery_registration/EyeSurgeryFormFragment.kt
@@ -211,7 +211,7 @@ class EyeSurgeryFormFragment : Fragment() {
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
 
-                    val result = FieldValidator.validate(updated, null)
+                    val result = FieldValidator.validate(updated, null, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
                     if (schemaField.fieldId == "visit_date" && schemaField.value is String) {

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/child_care/children_under_five_years/children_forms/CUFYFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/child_care/children_under_five_years/children_forms/CUFYFormFragment.kt
@@ -457,7 +457,7 @@ class CUFYFormFragment : Fragment() {
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
 
-                    val result = FieldValidator.validate(updated, dobString)
+                    val result = FieldValidator.validate(updated, dobString, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/disease_control/filaria/form/FilariaMDAFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/disease_control/filaria/form/FilariaMDAFormFragment.kt
@@ -226,7 +226,7 @@ class FilariaMDAFormFragment : Fragment() {
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
 
-                    val result = FieldValidator.validate(updated, null)
+                    val result = FieldValidator.validate(updated, null, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
                     if (schemaField.fieldId == "visit_date" && schemaField.value is String) {

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/disease_control/malaria/form/list/MalariaSuspectedListFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/disease_control/malaria/form/list/MalariaSuspectedListFragment.kt
@@ -337,7 +337,7 @@ class MalariaSuspectedListFragment : Fragment() {
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
 
-                    val result = FieldValidator.validate(updated, null)
+                    val result = FieldValidator.validate(updated, null, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
                     if (schemaField.fieldId == "visit_date" && schemaField.value is String) {

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/infant/hbnc/HBNCFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/infant/hbnc/HBNCFormFragment.kt
@@ -260,7 +260,7 @@ class HBNCFormFragment : Fragment() {
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
 
-                    val result = FieldValidator.validate(updated, dobString)
+                    val result = FieldValidator.validate(updated, dobString, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
                     if (schemaField.fieldId == "visit_date" && schemaField.value is String) {

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/infant/hbyc/HBYCFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/infant/hbyc/HBYCFormFragment.kt
@@ -210,7 +210,7 @@ class HBYCFormFragment : Fragment() {
             section.fields.orEmpty().forEach { schemaField ->
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
-                    val result = FieldValidator.validate(updated, dobString)
+                    val result = FieldValidator.validate(updated, dobString, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
 

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/village_level_forms/filaria_mda/FilariaMdaCampaignFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/village_level_forms/filaria_mda/FilariaMdaCampaignFormFragment.kt
@@ -269,7 +269,7 @@ class FilariaMdaCampaignFormFragment : Fragment() {
                 updatedFields.find { it.fieldId == schemaField.fieldId }?.let { updated ->
                     schemaField.value = updated.value
 
-                    val result = FieldValidator.validate(updated, null)
+                    val result = FieldValidator.validate(updated, null, context = requireContext())
                     updated.errorMessage = if (!result.isValid) result.errorMessage else null
                     schemaField.errorMessage = updated.errorMessage
                     if (schemaField.fieldId == "visit_date" && schemaField.value is String) {

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/village_level_forms/ors_campaign/ORSCampaignFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/village_level_forms/ors_campaign/ORSCampaignFormFragment.kt
@@ -264,7 +264,7 @@ class ORSCampaignFormFragment : Fragment() {
         val visibleFields = viewModel.getVisibleFields()
 
         val hasErrors = visibleFields.any { field ->
-            val result = FieldValidator.validate(field, null)
+            val result = FieldValidator.validate(field, null, context = requireContext())
             if (!result.isValid) {
                 field.errorMessage = result.errorMessage
                 true

--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/village_level_forms/pulse_polio/PulsePolioCampaignFormFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/village_level_forms/pulse_polio/PulsePolioCampaignFormFragment.kt
@@ -266,7 +266,7 @@ class PulsePolioCampaignFormFragment : Fragment() {
         val visibleFields = viewModel.getVisibleFields()
 
         val hasErrors = visibleFields.any { field ->
-            val result = FieldValidator.validate(field, null)
+            val result = FieldValidator.validate(field, null, context = requireContext())
             if (!result.isValid) {
                 field.errorMessage = result.errorMessage
                 true

--- a/app/src/main/java/org/piramalswasthya/sakhi/utils/SafeNestedScrollView.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/utils/SafeNestedScrollView.kt
@@ -1,0 +1,33 @@
+package org.piramalswasthya.sakhi.utils
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.core.widget.NestedScrollView
+
+/**
+ * A NestedScrollView that safely handles the case where onSizeChanged() tries to scroll
+ * to a focused view that is no longer a descendant of this scroll view.
+ *
+ * This can occur when a RecyclerView inside the scroll view has its adapter replaced while
+ * an EditText inside the RecyclerView has focus. RecyclerView internally detaches views
+ * before removing them, leaving a stale focused-view reference in the parent chain.
+ * When the scroll view resizes (e.g., keyboard dismissal), onSizeChanged() calls
+ * offsetDescendantRectToMyCoords() with the detached view, throwing
+ * IllegalArgumentException: "parameter must be a descendant of this view".
+ */
+class SafeNestedScrollView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : NestedScrollView(context, attrs, defStyleAttr) {
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        try {
+            super.onSizeChanged(w, h, oldw, oldh)
+        } catch (e: IllegalArgumentException) {
+            // Swallow: the focused child is no longer a descendant (detached during
+            // RecyclerView layout). The scroll-to-focused-child behavior is skipped,
+            // which is acceptable — the view is being replaced anyway.
+        }
+    }
+}

--- a/app/src/main/java/org/piramalswasthya/sakhi/utils/dynamicFiledValidator/FieldValidator.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/utils/dynamicFiledValidator/FieldValidator.kt
@@ -1,5 +1,7 @@
 package org.piramalswasthya.sakhi.utils.dynamicFiledValidator
 
+import android.content.Context
+import org.piramalswasthya.sakhi.R
 import org.piramalswasthya.sakhi.configuration.dynamicDataSet.FormField
 import java.text.SimpleDateFormat
 import java.util.*
@@ -23,9 +25,11 @@ object FieldValidator {
         )
     )
 
-    fun validate(field: FormField, dob: String?, todayStr: String = getToday()): ValidationResult {
+    fun validate(field: FormField, dob: String?, todayStr: String = getToday(), context: Context? = null): ValidationResult {
         if (field.isRequired && (field.value == null || field.value.toString().isBlank())) {
-            return ValidationResult(false, "${field.label} is required")
+            val msg = context?.getString(R.string.field_is_required, field.label)
+                ?: "${field.label} is required"
+            return ValidationResult(false, msg)
         }
 
         val valueStr = field.value.toString().trim()
@@ -35,7 +39,9 @@ object FieldValidator {
             "text" -> {
                 val regex = rules.regex
                 if (regex != null && !regex.toRegex().matches(valueStr)) {
-                    ValidationResult(false, rules.errorMessage ?: "${field.label} is invalid")
+                    val msg = context?.getString(R.string.field_is_invalid, field.label)
+                        ?: rules.errorMessage ?: "${field.label} is invalid"
+                    ValidationResult(false, msg)
                 } else {
                     ValidationResult(true)
                 }
@@ -43,16 +49,22 @@ object FieldValidator {
 
             "number" -> {
                 val num = valueStr.toFloatOrNull()
-                    ?: return ValidationResult(false, "${field.label} must be a number")
+                    ?: return ValidationResult(false,
+                        context?.getString(R.string.field_must_be_number, field.label)
+                            ?: "${field.label} must be a number")
 
                 val min = rules.min
                 val max = rules.max
 
                 if (min != null && num < min)
-                    return ValidationResult(false, "${field.label} should be at least $min")
+                    return ValidationResult(false,
+                        context?.getString(R.string.field_min_value, field.label, min.toString())
+                            ?: "${field.label} should be at least $min")
 
                 if (max != null && num > max)
-                    return ValidationResult(false, "${field.label} should be at most $max")
+                    return ValidationResult(false,
+                        context?.getString(R.string.field_max_value, field.label, max.toString())
+                            ?: "${field.label} should be at most $max")
 
                 ValidationResult(true)
             }
@@ -60,7 +72,9 @@ object FieldValidator {
             "date" -> {
                 val sdf = SimpleDateFormat("dd-MM-yyyy", Locale.ENGLISH)
                 val valueDate = runCatching { sdf.parse(valueStr) }.getOrNull()
-                    ?: return ValidationResult(false, "${field.label} date is invalid")
+                    ?: return ValidationResult(false,
+                        context?.getString(R.string.field_date_invalid, field.label)
+                            ?: "${field.label} date is invalid")
 
                 val minDate = when (rules.minDate) {
                     "dob" -> dob?.let { runCatching { sdf.parse(it) }.getOrNull() }
@@ -76,21 +90,24 @@ object FieldValidator {
 
                 if (minDate != null && valueDate.before(minDate)) {
                     val customMessage = fieldConfigs[field.fieldId]?.customMessages?.get("minDate")
-                    return ValidationResult(
-                        false,
-                        customMessage?.let { "${field.label} $it" }
+                    val msg = if (customMessage != null) {
+                        "${field.label} $customMessage"
+                    } else {
+                        context?.getString(R.string.field_date_before, field.label, rules.minDate)
                             ?: "${field.label} cannot be before ${rules.minDate}"
-
-                    )
+                    }
+                    return ValidationResult(false, msg)
                 }
 
                 if (maxDate != null && valueDate.after(maxDate)) {
                     val customMessage = fieldConfigs[field.fieldId]?.customMessages?.get("minDate")
-                    return ValidationResult(
-                        false,
-                        customMessage?.let { "${field.label} $it" }
+                    val msg = if (customMessage != null) {
+                        "${field.label} $customMessage"
+                    } else {
+                        context?.getString(R.string.field_date_after, field.label, rules.maxDate)
                             ?: "${field.label} cannot be after ${rules.maxDate}"
-                    )
+                    }
+                    return ValidationResult(false, msg)
                 }
 
                 ValidationResult(true)

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -737,7 +737,6 @@
     <string name="follow_up_form">ফল\' আপ ফৰ্ম</string>
     <string name="otp_resent">OTP পুনৰ প্ৰেৰণ কৰা হৈছে</string>
     <string name="non_follow_up_cases">ফল\' আপ নকৰা কেছ</string>
-    <string name="app_native_name">উৎপ্ৰেৰণা</string>
     <string name="visit_day">ভিজিটৰ দিন</string>
     <string name="date_of_diagnosis">ৰোগ নিৰ্ণয়ৰ তাৰিখ</string>
     <string name="time_of_death">মৃত্যুৰ সময়</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -226,6 +226,14 @@
     <string name="form_input_alphabet_space_only_error">केवल अक्षर और खाली जगह मान्य</string>
     <string name="form_input_alphabet_special_only_error">केवल अक्षर और विशेष चिन्ह मान्य</string>
     <string name="form_input_alph_numeric_space_only_error">केवल अक्षर और अंक मान्य</string>
+    <string name="field_is_required">%s आवश्यक है</string>
+    <string name="field_is_invalid">%s अमान्य है</string>
+    <string name="field_must_be_number">%s एक संख्या होनी चाहिए</string>
+    <string name="field_min_value">%1$s कम से कम %2$s होना चाहिए</string>
+    <string name="field_max_value">%1$s अधिकतम %2$s होना चाहिए</string>
+    <string name="field_date_invalid">%s तारीख अमान्य है</string>
+    <string name="field_date_before">%1$s %2$s से पहले नहीं हो सकता</string>
+    <string name="field_date_after">%1$s %2$s के बाद नहीं हो सकता</string>
     <string name="form_input__no_alpha_space_error">अक्षर या खाली जगह मान्य नहीं</string>
     <string name="form_input_digit_only_error">केवल अंक मान्य</string>
     <string name="form_input_min_limit_error_decimal">%1$s %2$.1f से अधिक या बराबर होना चाहिए</string>
@@ -640,7 +648,6 @@
     <string name="otp_resent">OTP पुनः भेजा गया</string>
     <string name="assamese">অসমীয়া</string>
     <string name="non_follow_up_cases">फॉलो-अप न किए गए केस</string>
-    <string name="app_native_name">उत्प्रेरणा</string>
     <string name="visit_day">विजिट दिन</string>
     <string name="date_of_diagnosis">निदान की तारीख</string>
     <string name="time_of_death">मृत्यु का समय</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,14 @@
     <string name="form_input_alphabet_special__digit_only_error">Only Alphabets and special characters, digits allowed!</string>
     <string name="form_input_min_limit_error">%1$s should be greater than or equal to %2$d</string>
     <string name="form_input_alph_numeric_space_only_error">Only Alphabets and Numerics allowed!</string>
+    <string name="field_is_required">%s is required</string>
+    <string name="field_is_invalid">%s is invalid</string>
+    <string name="field_must_be_number">%s must be a number</string>
+    <string name="field_min_value">%1$s should be at least %2$s</string>
+    <string name="field_max_value">%1$s should be at most %2$s</string>
+    <string name="field_date_invalid">%s date is invalid</string>
+    <string name="field_date_before">%1$s cannot be before %2$s</string>
+    <string name="field_date_after">%1$s cannot be after %2$s</string>
     <string name="abha_number_digit">ABHA number should be 14-digit long</string>
     <string name="ifsc">4 letters followed by 7 digits (e.g., ABCD1234567)!</string>
     <string name="ifsc_code">IFSC</string>


### PR DESCRIPTION
## 📋 Description

JIRA ID: FLW-877, FLW-878, FLW-853, FLW-879, FLW-880, FLW-865, FLW-885, FLW-886

## Summary                                                                                                                                                   
  - Fixed Village Meeting form dropdown validation (VHSNC, VHND/VHSND, Cluster Meeting) failing in Hindi — regex now supports Devanagari combining marks
  (`\p{M}`) alongside Unicode letters (`\p{L}`)
  - Localized dynamic form validation error messages (FieldValidator) — previously showed mixed Hindi/English like "तापमान is required", now fully translated
  (e.g., "तापमान आवश्यक है")
  - Added Hindi string resources for all 8 validation messages (required, invalid, number, min/max, date errors)
  - Updated all 10 FieldValidator call sites to pass context for localized strings
  - Fixed login screen showing "उत्प्रेरणा" instead of flavor name "मितानिन-Uat" in Hindi/Assamese by removing overriding app_native_name from localized strings

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [x] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [x] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [x] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## Test plan
  - [ ] Login with Hindi → verify title shows "मितानिन-Uat" (not "उत्प्रेरणा")
  - [ ] Login with Assamese → verify title shows "मितानिन-Uat"
  - [ ] Village Meetings → VHND/VHSND → fill new form → select "Place of VHND session" dropdown → verify no field error in Hindi
  - [ ] Repeat for VHSNC and Cluster Meeting forms
  - [ ] Open any dynamic form (HBNC/HBYC/SAM) in Hindi → submit empty → verify errors are fully in Hindi
  - [ ] Repeat in English → verify errors are in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added localized form validation error messages for improved user experience
  * Enhanced Unicode character support in form field validation

* **Bug Fixes**
  * Fixed potential crashes when scrolling through forms with dynamic field changes

* **Internationalization**
  * Added Hindi translations for form validation error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->