### PR TITLE
Fix NCD follow-up form field validation errors not clearing and empty multicheckbox bypass

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/adapters/dynamicAdapter/FormRendererAdapter.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/adapters/dynamicAdapter/FormRendererAdapter.kt
@@ -326,6 +326,7 @@
 
                         // Error TextView
                         val errorTextView = TextView(context).apply {
+                            tag = "field_error_tv"
                             setTextColor(Color.RED)
                             textSize = 12f
                             text = field.errorMessage ?: ""
@@ -1025,6 +1026,7 @@
                         wrapper.addView(radioGroup)
 
                         val errorTextView = TextView(itemView.context).apply {
+                            tag = "field_error_tv"
                             setTextColor(Color.RED)
                             textSize = 12f
                             text = field.errorMessage ?: ""

--- a/app/src/main/java/org/piramalswasthya/sakhi/utils/dynamicFiledValidator/FieldValidator.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/utils/dynamicFiledValidator/FieldValidator.kt
@@ -26,7 +26,8 @@ object FieldValidator {
     )
 
     fun validate(field: FormField, dob: String?, todayStr: String = getToday(), context: Context? = null): ValidationResult {
-        if (field.isRequired && (field.value == null || field.value.toString().isBlank())) {
+        if (field.isRequired && (field.value == null || field.value.toString().isBlank()
+                    || (field.value is Collection<*> && (field.value as Collection<*>).isEmpty()))) {
             val msg = context?.getString(R.string.field_is_required, field.label)
                 ?: "${field.label} is required"
             return ValidationResult(false, msg)


### PR DESCRIPTION
## 📋 Description

JIRA ID: FLW-896

##Summary:
- Added missing tag = "field_error_tv" to error TextViews for multicheckbox and radio field types in FormRendererAdapter, so validation errors properly hide when the user fills in those fields.
- Fixed FieldValidator to treat empty collections (e.g., all checkboxes unchecked) as missing values for required field validation, preventing form submission with no Diagnosis selected.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced required field validation to treat empty collections as invalid, ensuring users receive clear error messages when collection-type required fields lack values.

* **Improvements**
  * Refined error message display handling for consistent presentation across form field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->