### PR TITLE
Improve FLW Mobile App README setup and contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ Assam State.
 
 ## Technologies & Tools Used
 
-- **IDE**: Android Studio.
-- **Database**: Room
+- **IDE**: Android Studio
+- **Local Database**: Room 2.6.1
 - **Languages**: XML, Kotlin, SQL
-- **Architecture & Architectural Components**: MVVM, Android Architectural Components
-- **SDK**: Android SDK 23-34
+- **Architecture & Architectural Components**: MVVM, Repository pattern, ViewModel, LiveData
+- **Dependency Injection**: Hilt
+- **Background Work**: WorkManager 2.10.2
+- **Firebase**: Analytics, Crashlytics, Messaging, and Remote Config
+- **SDK**: Android SDK 23-35
+- **Product flavors**: saksham, sakshamUat, sakshamStag, niramay, xushrukha, mitanin, mitaninUat, mitaninStag
+- **Offline-first support**: data is stored locally in Room and synced with the server when connectivity is available
 
 ## Installation
 
@@ -105,11 +110,11 @@ To run this project, Follow these steps:
 3. Click on 'Open an existing Android Studio project'.
 4. Navigate to the directory where you cloned the project and select the root folder.
 5. Wait for Android Studio to sync the project and download the dependencies.
-6. Once the sync is done, select build variant you want to work on like uatDebug, statingDebug or productionDebug
-7. create folder in \app\src named production, uat or staging as per build variant you want to work and add google JSON file in it.
-7. Clean Project and Rebuild and run project 
-8. you can run the project on an emulator or a physical device.
-9. Try to login with valid Credentials if everything is fine you able to login successfully
+6. Once the sync is done, select the build variant you want to work on, such as sakshamDebug, sakshamUatDebug, or sakshamStagDebug.
+7. Add the `google-services.json` file inside the matching flavor folder under `app/src`, such as `app/src/saksham`, `app/src/sakshamUat`, or `app/src/sakshamStag`.
+8. Clean and rebuild the project.
+9. Run the project on an emulator or physical device.
+10. Try logging in with valid credentials. If the setup is correct, you should be able to log in successfully.
 
 ### Prerequisites
 
@@ -203,11 +208,15 @@ bash setup.sh
         + Once the APK is generated android studio will notify with the location of APK, 
              generally in release folder 
 
+## Contributing
+
+Before picking up an issue, please read the [CONTRIBUTOR_GUIDELINES.md](https://github.com/PSMRI/AMRIT/blob/main/CONTRIBUTOR_GUIDELINES.md). It covers issue assignment, expected timelines, and how to link your PR to the right issue.
+
 ## Filing Issues
 
-If you encounter any issues, bugs, or have feature requests, please file them in the [main AMRIT repository](https://github.com/PSMRI/AMRIT/issues). Centralizing all feedback helps us streamline improvements and address concerns efficiently.  
+If you encounter any issues, bugs, or have feature requests, please file them in the [main AMRIT repository](https://github.com/PSMRI/AMRIT/issues). Centralizing all feedback helps us streamline improvements and address concerns efficiently.
 
 ## Join Our Community
 
 We’d love to have you join our community discussions and get real-time support!  
-Join our [Discord server](https://discord.gg/FVQWsf5ENS) to connect with contributors, ask questions, and stay updated.  
+Join our [Discord server](https://discord.gg/FVQWsf5ENS) to connect with contributors, ask questions, and stay updated.


### PR DESCRIPTION
## Summary
Updated the README to make setup clearer for new contributors working on the FLW Mobile App.

## Changes
- Fixed the duplicate installation step number
- Corrected the build variant examples to current product flavors
- Added Room, Hilt, WorkManager, Firebase, SDK, and offline-first sync details
- Added a short contributing note with the contributor guidelines link

## Validation
- Ran `git diff --check`
- Docs-only change; Android build not required

Closes PSMRI/AMRIT#147