### PR TITLE
Add gamification trigger event contract documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Assam State.
 - **Offline Access**: Ability to use the app without an internet connection.
 - **Multilingual Support**: Ability to use app in different languages like English, Hindi, Assamese.
 
+## Documentation
+
+- [Gamification Trigger Event Contract](docs/GamificationTriggerEventContract.md)
+
 ## Technologies & Tools Used
 
 - **IDE**: Android Studio.

--- a/docs/GamificationTriggerEventContract.md
+++ b/docs/GamificationTriggerEventContract.md
@@ -1,0 +1,44 @@
+# Gamification Trigger Event Contract
+
+## Purpose
+
+The gamification module should receive workflow events from existing ASHA health flows and apply reward logic separately. This keeps points, streaks, badges, and progress tracking outside core data-entry screens.
+
+## Why This Is Needed
+
+ASHA workflows already cover registration, ANC/PNC visits, child health, NCD screening, immunization, and follow-up activities. Gamification should encourage timely and consistent use of these workflows without rewarding unnecessary raw entries.
+
+A common trigger event contract allows the app to capture local progress offline and reconcile rewards later after sync or validation.
+
+## Event Model
+
+Each workflow event should carry enough context for the gamification layer to decide rewards independently.
+
+| Field | Purpose |
+| --- | --- |
+| `workflowType` | Source workflow, such as registration, ANC/PNC, immunization, NCD, or child health. |
+| `eventAction` | Action completed, such as created, completed, synced, or validated. |
+| `localTimestamp` | Time when the event happened on device. |
+| `syncStatus` | Local, pending sync, synced, failed, or reconciled state. |
+| `recordId` | Beneficiary or workflow record reference. |
+| `ashaId` | ASHA or user reference. |
+| `validationStatus` | Optional supervisor/CHO validation status when available. |
+
+## Reward Flow
+
+1. Existing workflow completes a meaningful action.
+2. Workflow emits a gamification trigger event.
+3. Event is stored locally for offline support.
+4. Gamification logic calculates provisional progress.
+5. Sync or validation updates the event status.
+6. Final rewards are reconciled from accepted events.
+
+## Expected Benefits
+
+- Keeps health workflows focused on data entry.
+- Keeps gamification modular and testable.
+- Supports offline-first reward tracking.
+- Reduces risk of rewarding only raw submissions.
+- Gives future mechanics one shared integration point.
+
+Related issue: PSMRI/AMRIT#150


### PR DESCRIPTION
## Summary

- Add a gamification trigger event contract document
- Link the new document from the README
- Capture how existing ASHA workflows can emit events for rewards without coupling reward logic to health forms

## Why

Issue PSMRI/AMRIT#150 identifies the need for a clean contract between FLW workflows and the future gamification module. This document gives the proposal a concrete technical starting point for offline-first events, sync status, and validation-aware reward reconciliation.

## Validation

Docs-only change. No Android build required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Gamification Trigger Event Contract docs describing purpose, event model, reward flow, offline handling, and expected benefits.
  * Updated main project README to link to the new Gamification documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->