### PR TITLE
Fix: Prevent StackOverflowError on SocketTimeoutException in Incentiv…

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/repositories/IncentiveRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/repositories/IncentiveRepo.kt
@@ -43,7 +43,7 @@ class IncentiveRepo @Inject constructor(
     val activity_list = incentiveDao.getAllActivity()
 
 
-    suspend fun pullAndSaveAllIncentiveActivities(user: User): Boolean {
+    suspend fun pullAndSaveAllIncentiveActivities(user: User, retryCount: Int = 3): Boolean {
         return withContext(Dispatchers.IO) {
             try {
                 val currentLang = preferenceDao.getCurrentLanguage().symbol
@@ -94,8 +94,11 @@ class IncentiveRepo @Inject constructor(
 
             } catch (e: SocketTimeoutException) {
                 Timber.e("incentives error : $e")
-                pullAndSaveAllIncentiveActivities(user)
-                return@withContext true
+                if (retryCount > 0) {
+                    return@withContext pullAndSaveAllIncentiveActivities(user,retryCount - 1)
+                } else {
+                    return@withContext false
+                }
             } catch (e: Exception) {
                 Timber.d("Caught $e at incentives!")
                 return@withContext false
@@ -114,7 +117,7 @@ class IncentiveRepo @Inject constructor(
 
     }
 
-    suspend fun pullAndSaveAllIncentiveRecords(user: User): Boolean {
+    suspend fun pullAndSaveAllIncentiveRecords(user: User,retryCount: Int = 3): Boolean {
         return withContext(Dispatchers.IO) {
             try {
 
@@ -171,8 +174,11 @@ class IncentiveRepo @Inject constructor(
                 }
             } catch (e: SocketTimeoutException) {
                 Timber.e("incentives error : $e")
-                pullAndSaveAllIncentiveRecords(user)
-                return@withContext true
+                if (retryCount > 0) {
+                    return@withContext pullAndSaveAllIncentiveRecords(user, retryCount - 1)
+                } else {
+                    return@withContext false
+                }
             } catch (e: Exception) {
                 Timber.d("Caught $e at incentives!")
                 return@withContext false


### PR DESCRIPTION
## 📋 Description

**JIRA ID:** Resolves PSMRI/AMRIT#156

**Summary of the change:**
This PR fixes a critical bug in `IncentiveRepo.kt` where network calls catching a `SocketTimeoutException` were recursively calling themselves without any limit. A persistent network timeout would trigger an infinite loop, ultimately crashing the application with a `StackOverflowError`.

**Context & Motivation:**
* Added a `retryCount` parameter (defaulting to 3) to `pullAndSaveAllIncentiveActivities`.
* Added the same `retryCount` safeguard to `pullAndSaveAllIncentiveRecords`.
* Both functions now fail gracefully (`return@withContext false` or `true` depending on context) after exhausting the maximum retries.
* This brings `IncentiveRepo.kt` up to the same standard of safety already implemented in other repositories like `PmsmaRepo.kt` and `PncRepo.kt`.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [x] 🚀 **Performance** (improves performance / prevents memory exhaustion)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

**Testing & Verification:**
* Audited the codebase and verified that the Coroutine scope context utilizes `return@withContext` to properly escape the function upon retry exhaustion without leaking memory.
* Verified against `IncentiveRepo.kt` to ensure the `retryCount = 3` logic matches the established project standard for handling `SocketTimeoutException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network resilience for incentive data operations through the addition of automatic retry capability, improving handling of temporary connectivity and timeout issues.
  * Improved overall reliability and robustness of incentive activity and record data synchronization, ensuring more complete data retrieval even when initial network attempts encounter temporary disruptions or interruptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/FLW-Mobile-App/pull/442)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->