### PR TITLE
Fix: Update date parsing logic in VLFRepo to handle multiple ISO formats

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/repositories/VLFRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/repositories/VLFRepo.kt
@@ -1492,12 +1492,16 @@ class VLFRepo @Inject constructor(
         return combine(vhnd, vhnc, phc, ahd, deworming) { vhndList, vhncList, phcList, ahdList, dewormingCount ->
 
             fun isInCurrentMonth(dateStr: String?): Boolean {
-                return try {
-                    val date = LocalDate.parse(dateStr, formatter)
-                    YearMonth.from(date) == current
-                } catch (e: Exception) {
-                    false
+                if (dateStr.isNullOrBlank()) return false
+                for (formatter in formats) {
+                    try {
+                        val date = LocalDate.parse(dateStr, formatter)
+                        if (YearMonth.from(date) == current) return true
+                    } catch (e: Exception) {
+                        continue 
+                    }
                 }
+                return false
             }
 
             mapOf(

--- a/app/src/main/java/org/piramalswasthya/sakhi/repositories/VLFRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/repositories/VLFRepo.kt
@@ -1493,15 +1493,16 @@ class VLFRepo @Inject constructor(
 
             fun isInCurrentMonth(dateStr: String?): Boolean {
                 if (dateStr.isNullOrBlank()) return false
-                for (formatter in formats) {
+                val parsedDate = try {
+                    LocalDate.parse(dateStr, formatIndian)
+                } catch (e: java.time.format.DateTimeParseException) {
                     try {
-                        val date = LocalDate.parse(dateStr, formatter)
-                        if (YearMonth.from(date) == current) return true
-                    } catch (e: Exception) {
-                        continue 
+                        LocalDate.parse(dateStr, formatIso)
+                    } catch (e2: java.time.format.DateTimeParseException) {
+                        null
                     }
                 }
-                return false
+                return parsedDate != null && YearMonth.from(parsedDate) == current
             }
 
             mapOf(


### PR DESCRIPTION
## 📋 Description

**JIRA ID:** Resolves PSMRI/AMRIT#158

**Summary of the change:**
This PR fixes a silent UI bug where the dashboard incorrectly marks monthly forms as incomplete due to a strict `dd-MM-yyyy` date parsing expectation.

**Context & Motivation:**
In `VLFRepo.kt`, the `isInCurrentMonth` helper function was strictly using `DateTimeFormatter.ofPattern("dd-MM-yyyy")`. If a synced entity contained a standard ISO date (`yyyy-MM-dd`), `LocalDate.parse` threw an exception, which was silently caught and returned `false`. This caused the UI to lie to the user about their completion status.

I updated the logic to loop through a list of acceptable formats (both `dd-MM-yyyy` and `yyyy-MM-dd`), falling back gracefully if one fails, ensuring accurate completion checks regardless of the data source.

---
## ✅ Type of Change
- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] 🚀 **Performance**
- [ ] 🛠 **Refactor** ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form date field validation to handle multiple date formats and better reject invalid or blank date entries during submission.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/FLW-Mobile-App/pull/446)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->