### PR TITLE
Fix: Prevent silent deletion of offline records during down-sync

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/repositories/SaasBahuSammelanRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/repositories/SaasBahuSammelanRepo.kt
@@ -166,6 +166,7 @@ class SaasBahuSammelanRepo @Inject constructor(
         Log.e("AHJAHA",body)
         val adapter = moshi.adapter(SaasBahuSammelanGetAllResponse::class.java)
         val parsed = adapter.fromJson(body) ?: return@withContext
+        val unsyncedRecords = saasBahuDao.getBySyncState(SyncState.UNSYNCED)
         saasBahuDao.clearAll()
         parsed.data?.forEach { item ->
             val imageBase64List = item.meetingImages ?: emptyList()
@@ -199,6 +200,9 @@ class SaasBahuSammelanRepo @Inject constructor(
             )
 
             saasBahuDao.insertSammelan(entity)
+        }
+        unsyncedRecords.forEach {
+            saasBahuDao.insertSammelan(it)
         }
     }
 


### PR DESCRIPTION
## 📋 Description

**JIRA ID:** Resolves PSMRI/AMRIT#163

**Summary of the change:**
This PR resolves a critical data-loss vulnerability where unsynced offline work was being permanently deleted during server syncs.

**Context & Motivation:**
In `SaasBahuSammelanRepo.kt`, the down-sync routine executed `saasBahuDao.clearAll()` indiscriminately. In an offline-first environment, this meant any forms filled out locally (but not yet pushed to the server) were instantly destroyed when the device regained internet access and pulled server updates. 

I updated the logic to fetch and hold all `SyncState.UNSYNCED` records in memory prior to the `clearAll()` execution. Once the server data is successfully parsed and inserted, the unsynced local records are re-inserted, preserving the field worker's data integrity until the up-sync routine processes them.

---
## ✅ Type of Change
- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] 🚀 **Performance** - [ ] 🛠 **Refactor** ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where locally saved but unsynced changes were lost during server synchronization. The app now preserves unsaved local data when refreshing from the server.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/FLW-Mobile-App/pull/454)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->