### PR TITLE
Fix: Validate internal API status code to prevent false-positive sync…

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/repositories/MaaMeetingRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/repositories/MaaMeetingRepo.kt
@@ -110,7 +110,20 @@ class MaaMeetingRepo @Inject constructor(
                 meetingImages = imagesParts
             )
             if (response.isSuccessful) {
-                dao.updateSyncState(row.id, SyncState.SYNCED)
+                val responseString = response.body()?.string()
+                if (!responseString.isNullOrBlank()) {
+                    try {
+                        val jsonObj = org.json.JSONObject(responseString)
+                        val responseStatusCode = jsonObj.optInt("statusCode", -1)
+                        if (responseStatusCode == 200) {
+                            dao.updateSyncState(row.id, SyncState.SYNCED)
+                        } else {
+                            timber.log.Timber.e("MaaMeeting server rejected payload with status: $responseStatusCode")
+                        }
+                    } catch (e: Exception) {
+                        timber.log.Timber.e("Failed to parse MaaMeeting response: $e")
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## 📋 Description

**JIRA ID:** Resolves PSMRI/AMRIT#164

**Summary of the change:**
This PR patches a critical architecture vulnerability where `MaaMeeting` records were being falsely marked as `SYNCED` upon server rejections, leading to silent data loss.

**Context & Motivation:**
Unlike other repositories in this codebase that properly evaluate the backend's custom JSON `statusCode` wrapper, `MaaMeetingRepo.kt` was relying solely on Retrofit's `response.isSuccessful` (HTTP 200-299). Because the Amrit backend frequently responds with HTTP 200 even for business logic failures, any rejected `MaaMeeting` payload was being incorrectly treated as a success. This removed the unsynced record from the queue, meaning the health worker's data was lost forever and never retried.

I updated the up-sync routine to parse the JSON response body and strictly require an inner `statusCode == 200` before clearing the record from the sync queue, aligning it with the rest of the codebase.

---
## ✅ Type of Change
- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] 🚀 **Performance** - [ ] 🛠 **Refactor** ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced data synchronization to validate server response content before marking updates as synced, ensuring data consistency and preventing incorrect sync status assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/FLW-Mobile-App/pull/455)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->