### PR TITLE
Fix: Implement Mutex lock in up-sync to prevent race conditions and d…

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/repositories/SaasBahuSammelanRepo.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/repositories/SaasBahuSammelanRepo.kt
@@ -32,6 +32,8 @@ import java.io.File
 import java.net.SocketTimeoutException
 import javax.inject.Inject
 import kotlin.collections.forEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class SaasBahuSammelanRepo @Inject constructor(
     private val userRepo: UserRepo,
@@ -43,6 +45,8 @@ class SaasBahuSammelanRepo @Inject constructor(
 
 
 )  {
+    
+    private val syncMutex = Mutex()
 
     suspend fun saveSammelanForm(saasBahuSammelanCache: SaasBahuSammelanCache) {
         withContext(Dispatchers.IO) {
@@ -52,13 +56,14 @@ class SaasBahuSammelanRepo @Inject constructor(
 
      suspend fun pushUnSyncedRecordsSaasBahuSammelan(): Boolean {
 
-        return withContext(Dispatchers.IO) {
+        return syncMutex.withLock { withContext(Dispatchers.IO) {
             val user =
                 preferenceDao.getLoggedInUser()
                     ?: throw IllegalStateException("No user logged in!!")
 
             val saasBahuList: List<SaasBahuSammelanCache> =
                 saasBahuDao.getBySyncState(SyncState.UNSYNCED)
+            if (saasBahuList.isEmpty()) return@withContext true
             try {
                 saasBahuList.forEach { row ->
                     val imagesParts = (row.sammelanImages ?: emptyList()).mapNotNull { uriStr ->
@@ -134,7 +139,7 @@ class SaasBahuSammelanRepo @Inject constructor(
                 return@withContext false
             }
             true
-        }
+        }}
     }
 
 


### PR DESCRIPTION
## 📋 Description

**JIRA ID:** Resolves PSMRI/AMRIT#165

**Summary of the change:**
This PR introduces thread-safety to the up-sync architecture to prevent severe data duplication caused by overlapping sync operations.

**Context & Motivation:**
The `pushUnSyncedRecords` functions lacked concurrency protections. If multiple sync events fired simultaneously (e.g., button mashing, overlapping background/foreground syncs), a race condition occurred where multiple coroutines would read the same `UNSYNCED` database rows and upload identical payloads to the server simultaneously, polluting the backend with duplicate data.

I introduced a `Mutex` lock from `kotlinx.coroutines.sync`. By wrapping the read/upload execution inside `syncMutex.withLock { ... }`, we guarantee mutually exclusive access. If a second sync is triggered, it waits for the lock, and upon entry, immediately detects an empty list (since the first thread already marked them `SYNCED`) and safely exits.

---
## ✅ Type of Change
- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] 🛡️ **Security/Architecture** (Concurrency Safety)
- [ ] 🚀 **Performance** ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed critical data synchronization concurrency issues that could cause conflicts and data corruption during background record updates. Implemented proper synchronization locking to ensure only one sync operation runs at a time, preventing race conditions. This significantly improves overall reliability, stability, and data integrity across all background synchronization and update processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/FLW-Mobile-App/pull/456)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->