### PR TITLE
fix: FLW-1137 Brother-in-law option added for HoF Relations

### DIFF
--- a/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/all_household/AllHouseholdFragment.kt
+++ b/app/src/main/java/org/piramalswasthya/sakhi/ui/home_activity/all_household/AllHouseholdFragment.kt
@@ -416,6 +416,7 @@ class AllHouseholdFragment : Fragment() {
 
         if (hofGender == Gender.FEMALE && selectedGender == Gender.FEMALE) {
             list.remove(common[4])
+            list.remove(common[18])
         }
         return list
     }

--- a/app/src/main/res/values-as/strings_ben.xml
+++ b/app/src/main/res/values-as/strings_ben.xml
@@ -205,7 +205,22 @@
         <item>শহুৰেক</item>
         <item>নাতি</item>
         <item>জোঁৱাই</item>
+        <item>খুলশালি/দেওৰ</item>
         <item>অন্যান্য</item>
+    </string-array>
+
+    <string-array name="nbr_relationship_to_head_unmarried_filter">
+        <item>বউ</item>
+        <item>গৰু</item>
+        <item>পুত্ৰ</item>
+        <item>জীয়ৰী</item>
+        <item>বেহীৰীৰ পিতা</item>
+        <item>বেহীৰীৰ মা</item>
+        <item>ককাদেউতা</item>
+        <item>শহুৰেক</item>
+        <item>নাতি</item>
+        <item>জোঁৱাই</item>
+        <item>খুলশালি/দেওৰ</item>
     </string-array>
 
     <string-array name="nbr_relationship_to_head_src">
@@ -243,6 +258,7 @@
         <item>শহুৰেক</item>
         <item>নাতি</item>
         <item>জোঁৱাই</item>
+        <item>খুলশালি/দেওৰ</item>
         <item>অন্যান্য</item>
     </string-array>
 

--- a/app/src/main/res/values-bn/strings_ben.xml
+++ b/app/src/main/res/values-bn/strings_ben.xml
@@ -198,6 +198,7 @@
         <item>নাতনি</item>
         <item>জামাই</item>
         <item>পুত্রবধূ</item>
+        <item>শালা/দেবর</item>
         <item>অন্যান্য</item>
     </string-array>
 
@@ -212,6 +213,7 @@
         <item>নাতনি</item>
         <item>জামাই</item>
         <item>পুত্রবধূ</item>
+        <item>শালা/দেবর</item>
     </string-array>
 
     <string-array name="nbr_relationship_to_head_male">
@@ -224,6 +226,7 @@
         <item>শ্বশুর</item>
         <item>নাতি</item>
         <item>জামাই</item>
+        <item>শালা/দেবর</item>
         <item>অন্যান্য</item>
     </string-array>
 

--- a/app/src/main/res/values-hi/strings_ben.xml
+++ b/app/src/main/res/values-hi/strings_ben.xml
@@ -131,7 +131,21 @@
         <item>पोती/नातनी</item>
         <item>दामाद</item>
         <item>बहू</item>
+        <item>साला/देवर</item>
         <item>अन्य</item>
+    </string-array>
+    <string-array name="nbr_relationship_to_head_unmarried_filter">
+        <item>पत्नी</item>
+        <item>पिता</item>
+        <item>बेटा</item>
+        <item>बेटी</item>
+        <item>ससुर</item>
+        <item>सास</item>
+        <item>पोता</item>
+        <item>पोती/नातनी</item>
+        <item>दामाद</item>
+        <item>बहू</item>
+        <item>साला/देवर</item>
     </string-array>
     <string-array name="nbr_relationship_to_head_src">
         <item>मां</item>
@@ -168,6 +182,7 @@
         <item>ससुर</item>
         <item>पोता</item>
         <item>दामाद</item>
+        <item>साला/देवर</item>
         <item>अन्य</item>
     </string-array>
 

--- a/app/src/main/res/values/strings_ben.xml
+++ b/app/src/main/res/values/strings_ben.xml
@@ -202,6 +202,7 @@
         <item>Grand Daughter</item>
         <item>Son in Law</item>
         <item>Daughter in Law</item>
+        <item>Brother in Law</item>
         <item>Other</item>
     </string-array>
     <string-array name="nbr_relationship_to_head_unmarried_filter">
@@ -215,6 +216,7 @@
         <item>Grand Daughter</item>
         <item>Son in Law</item>
         <item>Daughter in Law</item>
+        <item>Brother in Law</item>
     </string-array>
 
     <string-array name="nbr_relationship_to_head_male">
@@ -227,6 +229,7 @@
         <item>Father in Law</item>
         <item>Grand Son</item>
         <item>Son in Law</item>
+        <item>Brother in Law</item>
         <item>Other</item>
     </string-array>
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: FLW-1137

In the Head of Family(Male/Female) relation, the "Brother-in-law" option was not available. Added this option.
Also added translations for all 4 languages: English, Hindi, Assamese, Bangle

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Brother-in-law” relationship options to beneficiary relationship lists in English, Hindi, Bengali, and Assamese.
  - Added relationship choices specifically for unmarried household members, including spouse, parents, children, in-laws, grandchildren, and siblings-in-law.
  - Expanded male relationship options with the new relationship entry.

- **Bug Fixes**
  - Corrected relationship filtering when both the household head and newly selected member are female.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->